### PR TITLE
bugfix: serve-static index file

### DIFF
--- a/backend/volume/src/app.module.ts
+++ b/backend/volume/src/app.module.ts
@@ -21,6 +21,9 @@ import { join } from 'path';
     ServeStaticModule.forRoot({
       rootPath: join('/usr/src/app/public/'), // this path has to change depending on the environment
       serveRoot: '/public',
+      serveStaticOptions: {
+        index: false
+      }
     }),
   ],
 })


### PR DESCRIPTION
I have found the option to turn off, now we have less errors.